### PR TITLE
#588: Allowing filtering based on SmoObject as opposed to just Name

### DIFF
--- a/src/Tests/Tests.SqlServerSchemaSettingsCustom.verified.sql
+++ b/src/Tests/Tests.SqlServerSchemaSettingsCustom.verified.sql
@@ -1,0 +1,26 @@
+﻿-- Tables
+
+CREATE TABLE [dbo].[MyTable](
+	[Value] [int] NULL
+) ON [PRIMARY]
+
+CREATE NONCLUSTERED INDEX [MyIndex] ON [dbo].[MyTable]
+(
+	[Value] ASC
+) ON [PRIMARY]
+
+CREATE TRIGGER MyTrigger
+ON MyTable
+AFTER UPDATE
+AS RAISERROR ('Notify Customer Relations', 16, 10);
+
+ALTER TABLE [dbo].[MyTable] ENABLE TRIGGER [MyTrigger]
+
+
+-- Views
+
+CREATE VIEW MyView
+AS
+  SELECT Value
+  FROM MyTable
+  WHERE (Value > 10);

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
 
@@ -245,6 +245,29 @@ public class Tests
                 tables: true,
                 views: true,
                 includeItem: itemName => itemName == "MyTable");
+
+        #endregion
+    }
+
+    [Test]
+    public async Task SqlServerSchemaSettingsCustom()
+    {
+        await using var database = await sqlInstance.Build();
+        var connection = database.Connection;
+
+        #region SqlServerSchemaSettings
+
+        await Verify(connection)
+            .SchemaSettings(new SchemaSettings
+            {
+                StoredProcedures = true,
+                UserDefinedFunctions = true,
+                Synonyms = true,
+                Tables = true,
+                Views = true,
+                // this should cover tables & views but not stored procs / others
+                IncludeItem = (item) => item is TableViewBase,
+            });
 
         #endregion
     }

--- a/src/Verify.SqlServer/SchemaValidation/SchemaSettings.cs
+++ b/src/Verify.SqlServer/SchemaValidation/SchemaSettings.cs
@@ -1,15 +1,11 @@
-﻿class SchemaSettings(
-    bool storedProcedures,
-    bool tables,
-    bool views,
-    bool userDefinedFunctions,
-    bool synonyms,
-    Func<string, bool> includeItem)
+using Microsoft.SqlServer.Management.Smo;
+
+public class SchemaSettings()
 {
-    public bool StoredProcedures { get; } = storedProcedures;
-    public bool Tables { get; } = tables;
-    public bool Views { get; } = views;
-    public bool Synonyms { get; } = synonyms;
-    public bool UserDefinedFunctions { get; } = userDefinedFunctions;
-    public Func<string, bool> IncludeItem { get; } = includeItem;
+    public bool StoredProcedures { get; init; } = true;
+    public bool Tables { get; init; } = true;
+    public bool Views { get; init; } = true;
+    public bool Synonyms { get; init; } = true;
+    public bool UserDefinedFunctions { get; init; } = true;
+    public Func<NamedSmoObject, bool> IncludeItem { get; init; } = (_) => true;
 }

--- a/src/Verify.SqlServer/SchemaValidation/SqlScriptBuilder.cs
+++ b/src/Verify.SqlServer/SchemaValidation/SqlScriptBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Microsoft.SqlServer.Management.Smo;
 
 class SqlScriptBuilder(SchemaSettings settings)
@@ -122,7 +122,7 @@ class SqlScriptBuilder(SchemaSettings settings)
         where T : NamedSmoObject, IScriptable
     {
         var filtered = items.Cast<T>()
-            .Where(_ => !isSystem(_) && settings.IncludeItem(_.Name))
+            .Where(_ => !isSystem(_) && settings.IncludeItem(_))
             .ToList();
         if (filtered.Count == 0)
         {

--- a/src/Verify.SqlServer/SchemaValidation/VerifySettingsExtensions.cs
+++ b/src/Verify.SqlServer/SchemaValidation/VerifySettingsExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace VerifyTests;
+namespace VerifyTests;
 
 public static class VerifySettingsSqlExtensions
 {
@@ -34,13 +34,23 @@ public static class VerifySettingsSqlExtensions
 
         settings.Context.Add(
             "SqlServer",
-            new SchemaSettings(
-                storedProcedures,
-                tables,
-                views,
-                userDefinedFunctions,
-                synonyms,
-                includeItem));
+            new SchemaSettings
+            {
+                StoredProcedures = storedProcedures,
+                Tables = tables,
+                Views = views,
+                UserDefinedFunctions = userDefinedFunctions,
+                Synonyms = synonyms,
+                IncludeItem = (_) => includeItem(_.Name),
+            });
+    }
+
+    public static void SchemaSettings(this VerifySettings settings, SchemaSettings schema) => settings.Context.Add("SqlServer", schema);
+
+    public static SettingsTask SchemaSettings(this SettingsTask settings, SchemaSettings schema)
+    {
+        settings.CurrentSettings.SchemaSettings(schema);
+        return settings;
     }
 
     internal static SchemaSettings GetSchemaSettings(this IReadOnlyDictionary<string, object> context)
@@ -53,5 +63,5 @@ public static class VerifySettingsSqlExtensions
         return defaultSettings;
     }
 
-    static SchemaSettings defaultSettings = new(true, true, true, true, true, _ => true);
+    static SchemaSettings defaultSettings = new();
 }


### PR DESCRIPTION
Fixes #588 

The changes here are backwards compatible because SchemaSettings previously was internal and not public.  I've changed it to be public because it's got many booleans (and I think it's reasonable to expect it to expand in future) and having many booleans in a function is typically written worse than using an object.

I'm happy to revert this sort of "secondary" change and keep the object internal if there is a reason why it's not desired.

I also added a simple test.