### PR TITLE
Add better Command support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ This test:
 ```cs
 await Verify(connection);
 ```
-<sup><a href='/src/Tests/Tests.cs#L81-L85' title='Snippet source file'>snippet source</a> | <a href='#snippet-SqlServerSchema' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L80-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-SqlServerSchema' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Will result in the following verified file:
@@ -128,7 +128,7 @@ await Verify(connection)
     // include only tables and views
     .SchemaIncludes(DbObjects.Tables | DbObjects.Views);
 ```
-<sup><a href='/src/Tests/Tests.cs#L389-L395' title='Snippet source file'>snippet source</a> | <a href='#snippet-SchemaInclude' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L388-L394' title='Snippet source file'>snippet source</a> | <a href='#snippet-SchemaInclude' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Available values:
@@ -166,7 +166,7 @@ await Verify(connection)
         _ => _ is TableViewBase ||
              _.Name == "MyTrigger");
 ```
-<sup><a href='/src/Tests/Tests.cs#L414-L422' title='Snippet source file'>snippet source</a> | <a href='#snippet-SchemaFilter' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L413-L421' title='Snippet source file'>snippet source</a> | <a href='#snippet-SchemaFilter' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -188,7 +188,7 @@ command.CommandText = "select Value from MyTable";
 var value = await command.ExecuteScalarAsync();
 await Verify(value!);
 ```
-<sup><a href='/src/Tests/Tests.cs#L223-L233' title='Snippet source file'>snippet source</a> | <a href='#snippet-Recording' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L222-L232' title='Snippet source file'>snippet source</a> | <a href='#snippet-Recording' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Will result in the following verified file:
@@ -198,9 +198,9 @@ Will result in the following verified file:
 ```txt
 {
   target: 42,
-  sql: {
-    HasTransaction: false,
-    Text: select Value from MyTable
+  sqlCommand: {
+    Text: select Value from MyTable,
+    HasTransaction: false
   }
 }
 ```
@@ -230,7 +230,7 @@ await Verify(
         sql = entries
     });
 ```
-<sup><a href='/src/Tests/Tests.cs#L340-L359' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingSpecific' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L339-L358' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingSpecific' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ await Verify(connection)
     // include only tables and views
     .SchemaIncludes(DbObjects.Tables | DbObjects.Views);
 ```
-<sup><a href='/src/Tests/Tests.cs#L388-L394' title='Snippet source file'>snippet source</a> | <a href='#snippet-SchemaInclude' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L459-L465' title='Snippet source file'>snippet source</a> | <a href='#snippet-SchemaInclude' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Available values:
@@ -166,7 +166,7 @@ await Verify(connection)
         _ => _ is TableViewBase ||
              _.Name == "MyTrigger");
 ```
-<sup><a href='/src/Tests/Tests.cs#L413-L421' title='Snippet source file'>snippet source</a> | <a href='#snippet-SchemaFilter' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L484-L492' title='Snippet source file'>snippet source</a> | <a href='#snippet-SchemaFilter' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -219,18 +219,62 @@ Recording.Start();
 await using var command = connection.CreateCommand();
 command.CommandText = "select Value from MyTable";
 var value = await command.ExecuteScalarAsync();
+
+await using var errorCommand = connection.CreateCommand();
+errorCommand.CommandText = "select Value from BadTable";
+try
+{
+    await errorCommand.ExecuteScalarAsync();
+}
+catch
+{
+}
+
 var entries = Recording
     .Stop()
     .Select(_ => _.Data);
-//TODO: optionally filter the results
+//Optionally filter results
 await Verify(
     new
     {
         value,
-        sql = entries
+        sqlEntries = entries
     });
 ```
-<sup><a href='/src/Tests/Tests.cs#L339-L358' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingSpecific' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L339-L369' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingSpecific' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+
+#### Interpreting recording results
+
+Recording results can be interpreted in a a variety of ways:
+
+<!-- snippet: RecordingReadingResults -->
+<a id='snippet-RecordingReadingResults'></a>
+```cs
+var entries = Recording.Stop();
+
+// successful Commands via Type
+var sqlCommandsViaType = entries
+    .Select(_ => _.Data)
+    .OfType<SqlCommand>();
+
+// successful Commands via key
+var sqlCommandsViaKey = entries
+    .Where(_ => _.Name == "sqlCommand")
+    .Select(_ => (SqlCommand) _.Data);
+
+// failed Commands via Type
+var sqlErrorsViaType = entries
+    .Select(_ => _.Data)
+    .OfType<LogErrorEntry>();
+
+// failed Commands via key
+var sqlErrorsViaKey = entries
+    .Where(_ => _.Name == "sqlError")
+    .Select(_ => (LogErrorEntry) _.Data);
+```
+<sup><a href='/src/Tests/Tests.cs#L395-L419' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingReadingResults' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ This test:
 ```cs
 await Verify(connection);
 ```
-<sup><a href='/src/Tests/Tests.cs#L80-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-SqlServerSchema' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L81-L85' title='Snippet source file'>snippet source</a> | <a href='#snippet-SqlServerSchema' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Will result in the following verified file:
@@ -128,7 +128,7 @@ await Verify(connection)
     // include only tables and views
     .SchemaIncludes(DbObjects.Tables | DbObjects.Views);
 ```
-<sup><a href='/src/Tests/Tests.cs#L344-L350' title='Snippet source file'>snippet source</a> | <a href='#snippet-SchemaInclude' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L389-L395' title='Snippet source file'>snippet source</a> | <a href='#snippet-SchemaInclude' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Available values:
@@ -166,7 +166,7 @@ await Verify(connection)
         _ => _ is TableViewBase ||
              _.Name == "MyTrigger");
 ```
-<sup><a href='/src/Tests/Tests.cs#L369-L377' title='Snippet source file'>snippet source</a> | <a href='#snippet-SchemaFilter' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L414-L422' title='Snippet source file'>snippet source</a> | <a href='#snippet-SchemaFilter' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -188,7 +188,7 @@ command.CommandText = "select Value from MyTable";
 var value = await command.ExecuteScalarAsync();
 await Verify(value!);
 ```
-<sup><a href='/src/Tests/Tests.cs#L178-L188' title='Snippet source file'>snippet source</a> | <a href='#snippet-Recording' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L223-L233' title='Snippet source file'>snippet source</a> | <a href='#snippet-Recording' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Will result in the following verified file:
@@ -230,7 +230,7 @@ await Verify(
         sql = entries
     });
 ```
-<sup><a href='/src/Tests/Tests.cs#L295-L314' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingSpecific' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L340-L359' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingSpecific' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/Tests/Tests.MsCommandEmpty.verified.txt
+++ b/src/Tests/Tests.MsCommandEmpty.verified.txt
@@ -1,4 +1,4 @@
 ﻿{
   CommandText: select * from MyTable,
-  CommandTimeout: 30
+  HasTransaction: false
 }

--- a/src/Tests/Tests.MsCommandEmpty.verified.txt
+++ b/src/Tests/Tests.MsCommandEmpty.verified.txt
@@ -1,0 +1,4 @@
+﻿{
+  CommandText: select * from MyTable,
+  CommandTimeout: 30
+}

--- a/src/Tests/Tests.MsCommandEmpty.verified.txt
+++ b/src/Tests/Tests.MsCommandEmpty.verified.txt
@@ -1,4 +1,4 @@
 ﻿{
-  CommandText: select * from MyTable,
+  Text: select * from MyTable,
   HasTransaction: false
 }

--- a/src/Tests/Tests.MsCommandFull.verified.txt
+++ b/src/Tests/Tests.MsCommandFull.verified.txt
@@ -3,6 +3,7 @@
   Parameters: {
     name: 10
   },
+  HasTransaction: false,
   CommandTimeout: 10,
   CommandType: StoredProcedure,
   Notification: {

--- a/src/Tests/Tests.MsCommandFull.verified.txt
+++ b/src/Tests/Tests.MsCommandFull.verified.txt
@@ -1,0 +1,15 @@
+﻿{
+  CommandText: select * from MyTable,
+  Parameters: {
+    name: 10
+  },
+  CommandTimeout: 10,
+  CommandType: StoredProcedure,
+  Notification: {
+    Options: options,
+    Timeout: 10,
+    UserData: user data
+  },
+  UpdatedRowSource: FirstReturnedRecord,
+  EnableOptimizedParameterBinding: true
+}

--- a/src/Tests/Tests.MsCommandFull.verified.txt
+++ b/src/Tests/Tests.MsCommandFull.verified.txt
@@ -1,11 +1,11 @@
 ﻿{
-  CommandText: select * from MyTable,
+  Text: select * from MyTable,
   Parameters: {
     name: 10
   },
   HasTransaction: false,
-  CommandTimeout: 10,
-  CommandType: StoredProcedure,
+  Timeout: 10,
+  Type: StoredProcedure,
   Notification: {
     Options: options,
     Timeout: 10,

--- a/src/Tests/Tests.RecordingError.verified.txt
+++ b/src/Tests/Tests.RecordingError.verified.txt
@@ -1,11 +1,13 @@
 ﻿{
-  sql: {
-    HasTransaction: false,
+  sqlError: {
     Exception: {
       Message: Invalid object name 'MyTabl2e'.,
       Number: 208,
       Line: 1
     },
-    Text: select * from MyTabl2e
+    Command: {
+      Text: select * from MyTabl2e,
+      HasTransaction: false
+    }
   }
 }

--- a/src/Tests/Tests.RecordingReadingResults.verified.txt
+++ b/src/Tests/Tests.RecordingReadingResults.verified.txt
@@ -1,0 +1,40 @@
+﻿{
+  sqlCommandsViaType: [
+    {
+      Text: select Value from MyTable,
+      HasTransaction: false
+    }
+  ],
+  sqlCommandsViaKey: [
+    {
+      Text: select Value from MyTable,
+      HasTransaction: false
+    }
+  ],
+  sqlErrorsViaType: [
+    {
+      Exception: {
+        Message: Invalid object name 'BadTable'.,
+        Number: 208,
+        Line: 1
+      },
+      Command: {
+        Text: select Value from BadTable,
+        HasTransaction: false
+      }
+    }
+  ],
+  sqlErrorsViaKey: [
+    {
+      Exception: {
+        Message: Invalid object name 'BadTable'.,
+        Number: 208,
+        Line: 1
+      },
+      Command: {
+        Text: select Value from BadTable,
+        HasTransaction: false
+      }
+    }
+  ]
+}

--- a/src/Tests/Tests.RecordingSpecific.verified.txt
+++ b/src/Tests/Tests.RecordingSpecific.verified.txt
@@ -2,8 +2,8 @@
   value: 42,
   sql: [
     {
-      HasTransaction: false,
-      Text: select Value from MyTable
+      Text: select Value from MyTable,
+      HasTransaction: false
     }
   ]
 }

--- a/src/Tests/Tests.RecordingSpecific.verified.txt
+++ b/src/Tests/Tests.RecordingSpecific.verified.txt
@@ -1,9 +1,20 @@
 ﻿{
   value: 42,
-  sql: [
+  sqlEntries: [
     {
       Text: select Value from MyTable,
       HasTransaction: false
+    },
+    {
+      Exception: {
+        Message: Invalid object name 'BadTable'.,
+        Number: 208,
+        Line: 1
+      },
+      Command: {
+        Text: select Value from BadTable,
+        HasTransaction: false
+      }
     }
   ]
 }

--- a/src/Tests/Tests.RecordingTest.verified.txt
+++ b/src/Tests/Tests.RecordingTest.verified.txt
@@ -1,16 +1,16 @@
 ﻿{
-  sql: [
+  sqlCommand: [
     {
-      HasTransaction: false,
-      Text: select * from MyTable
+      Text: select * from MyTable,
+      HasTransaction: false
     },
     {
-      HasTransaction: false,
-      Text: select * from MyTable
+      Text: select * from MyTable,
+      HasTransaction: false
     },
     {
-      HasTransaction: false,
-      Text: select * from MyTable
+      Text: select * from MyTable,
+      HasTransaction: false
     }
   ]
 }

--- a/src/Tests/Tests.RecordingUsage.verified.txt
+++ b/src/Tests/Tests.RecordingUsage.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
   target: 42,
-  sql: {
-    HasTransaction: false,
-    Text: select Value from MyTable
+  sqlCommand: {
+    Text: select Value from MyTable,
+    HasTransaction: false
   }
 }

--- a/src/Tests/Tests.RecordingWithParameter.verified.txt
+++ b/src/Tests/Tests.RecordingWithParameter.verified.txt
@@ -1,10 +1,10 @@
 ﻿{
   target: null,
-  sql: {
-    HasTransaction: false,
+  sqlCommand: {
+    Text: select Value from MyTable where Value = @param,
     Parameters: {
       param: 10
     },
-    Text: select Value from MyTable where Value = @param
+    HasTransaction: false
   }
 }

--- a/src/Tests/Tests.SysCommandEmpty.verified.txt
+++ b/src/Tests/Tests.SysCommandEmpty.verified.txt
@@ -1,4 +1,5 @@
 ﻿{
   CommandText: select * from MyTabl2e,
+  HasTransaction: false,
   CommandTimeout: 30
 }

--- a/src/Tests/Tests.SysCommandEmpty.verified.txt
+++ b/src/Tests/Tests.SysCommandEmpty.verified.txt
@@ -1,4 +1,4 @@
 ﻿{
-  CommandText: select * from MyTabl2e,
+  Text: select * from MyTabl2e,
   HasTransaction: false
 }

--- a/src/Tests/Tests.SysCommandEmpty.verified.txt
+++ b/src/Tests/Tests.SysCommandEmpty.verified.txt
@@ -1,5 +1,4 @@
 ﻿{
   CommandText: select * from MyTabl2e,
-  HasTransaction: false,
-  CommandTimeout: 30
+  HasTransaction: false
 }

--- a/src/Tests/Tests.SysCommandEmpty.verified.txt
+++ b/src/Tests/Tests.SysCommandEmpty.verified.txt
@@ -1,0 +1,4 @@
+﻿{
+  CommandText: select * from MyTabl2e,
+  CommandTimeout: 30
+}

--- a/src/Tests/Tests.SysCommandFull.verified.txt
+++ b/src/Tests/Tests.SysCommandFull.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  CommandText: select * from MyTable,
+  Parameters: {
+    name: 10
+  },
+  CommandTimeout: 10,
+  CommandType: StoredProcedure,
+  Notification: {
+    Options: options,
+    Timeout: 10,
+    UserData: user data
+  },
+  UpdatedRowSource: FirstReturnedRecord
+}

--- a/src/Tests/Tests.SysCommandFull.verified.txt
+++ b/src/Tests/Tests.SysCommandFull.verified.txt
@@ -3,6 +3,7 @@
   Parameters: {
     name: 10
   },
+  HasTransaction: false,
   CommandTimeout: 10,
   CommandType: StoredProcedure,
   Notification: {

--- a/src/Tests/Tests.SysCommandFull.verified.txt
+++ b/src/Tests/Tests.SysCommandFull.verified.txt
@@ -1,11 +1,11 @@
 ﻿{
-  CommandText: select * from MyTable,
+  Text: select * from MyTable,
   Parameters: {
     name: 10
   },
   HasTransaction: false,
-  CommandTimeout: 10,
-  CommandType: StoredProcedure,
+  Timeout: 10,
+  Type: StoredProcedure,
   Notification: {
     Options: options,
     Timeout: 10,

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Data.SqlTypes;
+using Microsoft.Data.Sql;
 using Microsoft.Data.SqlClient;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
@@ -138,6 +139,50 @@ public class Tests
 
         await Verify()
             .ScrubLinesContaining("HelpLink.ProdVer");
+    }
+
+    [Test]
+    public async Task MsCommandEmpty()
+    {
+        var command = new SqlCommand();
+        command.CommandText = "select * from MyTable";
+        await Verify(command);
+    }
+
+    [Test]
+    public async Task MsCommandFull()
+    {
+        var command = new SqlCommand();
+        command.CommandText = "select * from MyTable";
+        command.CommandTimeout = 10;
+        command.CommandType = CommandType.StoredProcedure;
+        command.DesignTimeVisible = true;
+        command.UpdatedRowSource = UpdateRowSource.FirstReturnedRecord;
+        command.EnableOptimizedParameterBinding = true;
+        command.Notification = new("user data","options", 10);
+        command.Parameters.AddWithValue("name", 10);
+        await Verify(command);
+    }
+
+    [Test]
+    public async Task SysCommandEmpty()
+    {
+        var command = new System.Data.SqlClient.SqlCommand();
+        command.CommandText = "select * from MyTabl2e";
+        await Verify(command);
+    }
+    [Test]
+    public async Task SysCommandFull()
+    {
+        var command = new System.Data.SqlClient.SqlCommand();
+        command.CommandText = "select * from MyTable";
+        command.CommandTimeout = 10;
+        command.CommandType = CommandType.StoredProcedure;
+        command.DesignTimeVisible = true;
+        command.UpdatedRowSource = UpdateRowSource.FirstReturnedRecord;
+        command.Notification = new("user data","options", 10);
+        command.Parameters.AddWithValue("name", 10);
+        await Verify(command);
     }
 
     [Test]

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -1,6 +1,5 @@
 using System.Data;
 using System.Data.SqlTypes;
-using Microsoft.Data.Sql;
 using Microsoft.Data.SqlClient;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;

--- a/src/Verify.SqlServer/Converters/MsCommandConverter.cs
+++ b/src/Verify.SqlServer/Converters/MsCommandConverter.cs
@@ -6,8 +6,9 @@
         writer.WriteStartObject();
         writer.WriteMember(command, command.CommandText, "CommandText");
         writer.WriteMember(command, command.Parameters, "Parameters");
+        writer.WriteMember(command, command.Transaction != null, "HasTransaction");
 
-        if (command.CommandTimeout != 30000)
+        if (command.CommandTimeout != 30)
         {
             writer.WriteMember(command, command.CommandTimeout, "CommandTimeout");
         }

--- a/src/Verify.SqlServer/Converters/MsCommandConverter.cs
+++ b/src/Verify.SqlServer/Converters/MsCommandConverter.cs
@@ -1,0 +1,39 @@
+﻿class MsCommandConverter :
+    WriteOnlyJsonConverter<MsCommand>
+{
+    public override void Write(VerifyJsonWriter writer, MsCommand command)
+    {
+        writer.WriteStartObject();
+        writer.WriteMember(command, command.CommandText, "CommandText");
+        writer.WriteMember(command, command.Parameters, "Parameters");
+
+        if (command.CommandTimeout != 30000)
+        {
+            writer.WriteMember(command, command.CommandTimeout, "CommandTimeout");
+        }
+
+        if (command.CommandType != CommandType.Text)
+        {
+            writer.WriteMember(command, command.CommandType, "CommandType");
+        }
+
+        if (!command.DesignTimeVisible)
+        {
+            writer.WriteMember(command, command.DesignTimeVisible, "DesignTimeVisible");
+        }
+
+        writer.WriteMember(command, command.Notification, "Notification");
+
+        if (command.UpdatedRowSource != UpdateRowSource.Both)
+        {
+            writer.WriteMember(command, command.UpdatedRowSource, "UpdatedRowSource");
+        }
+
+        if (command.EnableOptimizedParameterBinding)
+        {
+            writer.WriteMember(command, command.EnableOptimizedParameterBinding, "EnableOptimizedParameterBinding");
+        }
+
+        writer.WriteEndObject();
+    }
+}

--- a/src/Verify.SqlServer/Converters/MsCommandConverter.cs
+++ b/src/Verify.SqlServer/Converters/MsCommandConverter.cs
@@ -4,18 +4,18 @@
     public override void Write(VerifyJsonWriter writer, MsCommand command)
     {
         writer.WriteStartObject();
-        writer.WriteMember(command, command.CommandText, "CommandText");
+        writer.WriteMember(command, command.CommandText, "Text");
         writer.WriteMember(command, command.Parameters, "Parameters");
         writer.WriteMember(command, command.Transaction != null, "HasTransaction");
 
         if (command.CommandTimeout != 30)
         {
-            writer.WriteMember(command, command.CommandTimeout, "CommandTimeout");
+            writer.WriteMember(command, command.CommandTimeout, "Timeout");
         }
 
         if (command.CommandType != CommandType.Text)
         {
-            writer.WriteMember(command, command.CommandType, "CommandType");
+            writer.WriteMember(command, command.CommandType, "Type");
         }
 
         if (!command.DesignTimeVisible)

--- a/src/Verify.SqlServer/Converters/SysCommandConverter.cs
+++ b/src/Verify.SqlServer/Converters/SysCommandConverter.cs
@@ -6,8 +6,9 @@
         writer.WriteStartObject();
         writer.WriteMember(command, command.CommandText, "CommandText");
         writer.WriteMember(command, command.Parameters, "Parameters");
+        writer.WriteMember(command, command.Transaction != null, "HasTransaction");
 
-        if (command.CommandTimeout != 30000)
+        if (command.CommandTimeout != 30)
         {
             writer.WriteMember(command, command.CommandTimeout, "CommandTimeout");
         }

--- a/src/Verify.SqlServer/Converters/SysCommandConverter.cs
+++ b/src/Verify.SqlServer/Converters/SysCommandConverter.cs
@@ -4,18 +4,18 @@
     public override void Write(VerifyJsonWriter writer, SysCommand command)
     {
         writer.WriteStartObject();
-        writer.WriteMember(command, command.CommandText, "CommandText");
+        writer.WriteMember(command, command.CommandText, "Text");
         writer.WriteMember(command, command.Parameters, "Parameters");
         writer.WriteMember(command, command.Transaction != null, "HasTransaction");
 
         if (command.CommandTimeout != 30)
         {
-            writer.WriteMember(command, command.CommandTimeout, "CommandTimeout");
+            writer.WriteMember(command, command.CommandTimeout, "Timeout");
         }
 
         if (command.CommandType != CommandType.Text)
         {
-            writer.WriteMember(command, command.CommandType, "CommandType");
+            writer.WriteMember(command, command.CommandType, "Type");
         }
 
         if (!command.DesignTimeVisible)

--- a/src/Verify.SqlServer/Converters/SysCommandConverter.cs
+++ b/src/Verify.SqlServer/Converters/SysCommandConverter.cs
@@ -1,0 +1,34 @@
+﻿class SysCommandConverter :
+    WriteOnlyJsonConverter<SysCommand>
+{
+    public override void Write(VerifyJsonWriter writer, SysCommand command)
+    {
+        writer.WriteStartObject();
+        writer.WriteMember(command, command.CommandText, "CommandText");
+        writer.WriteMember(command, command.Parameters, "Parameters");
+
+        if (command.CommandTimeout != 30000)
+        {
+            writer.WriteMember(command, command.CommandTimeout, "CommandTimeout");
+        }
+
+        if (command.CommandType != CommandType.Text)
+        {
+            writer.WriteMember(command, command.CommandType, "CommandType");
+        }
+
+        if (!command.DesignTimeVisible)
+        {
+            writer.WriteMember(command, command.DesignTimeVisible, "DesignTimeVisible");
+        }
+
+        writer.WriteMember(command, command.Notification, "Notification");
+
+        if (command.UpdatedRowSource != UpdateRowSource.Both)
+        {
+            writer.WriteMember(command, command.UpdatedRowSource, "UpdatedRowSource");
+        }
+
+        writer.WriteEndObject();
+    }
+}

--- a/src/Verify.SqlServer/Recording/Listener.cs
+++ b/src/Verify.SqlServer/Recording/Listener.cs
@@ -21,19 +21,19 @@ class Listener :
 
     [DiagnosticName("System.Data.SqlClient.WriteCommandAfter")]
     public void OnSystemCommandAfter(SysCommand command) =>
-        Recording.TryAdd("sql", new LogEntry(command));
+        Recording.TryAdd("sqlCommand", command.Clone());
 
     [DiagnosticName("Microsoft.Data.SqlClient.WriteCommandAfter")]
     public void OnMsCommandAfter(MsCommand command) =>
-        Recording.TryAdd("sql", new LogEntry(command));
+        Recording.TryAdd("sqlCommand", command.Clone());
 
     [DiagnosticName("System.Data.SqlClient.WriteCommandError")]
     public void OnSysErrorExecuteCommand(SysCommand command, SysException exception) =>
-        Recording.TryAdd("sql", new LogEntry(command, exception));
+        Recording.TryAdd("sqlError", new LogErrorEntry(command.Clone(), exception));
 
     [DiagnosticName("Microsoft.Data.SqlClient.WriteCommandError")]
     public void OnMsErrorExecuteCommand(MsCommand command, MsException exception) =>
-        Recording.TryAdd("sql", new LogEntry(command, exception));
+        Recording.TryAdd("sqlError", new LogErrorEntry(command.Clone(), exception));
 
     void Clear()
     {

--- a/src/Verify.SqlServer/Recording/LogEntry.cs
+++ b/src/Verify.SqlServer/Recording/LogEntry.cs
@@ -1,9 +1,7 @@
 ﻿namespace VerifyTests.SqlServer;
 
-public class LogEntry(DbCommand command, DbException? exception = null)
+public class LogErrorEntry(DbCommand command, DbException exception)
 {
-    public bool HasTransaction { get; } = command.Transaction != null;
-    public DbException? Exception { get; } = exception;
-    public DbParameterCollection Parameters { get; } = command.Parameters;
-    public string Text { get; } = command.CommandText.Trim();
+    public DbException Exception { get; } = exception;
+    public DbCommand Command { get; } = command;
 }

--- a/src/Verify.SqlServer/VerifySqlServer.cs
+++ b/src/Verify.SqlServer/VerifySqlServer.cs
@@ -21,11 +21,13 @@ public static class VerifySqlServer
             var converters = settings.Converters;
             converters.Add(new MsErrorConverter());
             converters.Add(new MsConnectionConverter());
+            converters.Add(new MsCommandConverter());
             converters.Add(new MsExceptionConverter());
             converters.Add(new MsParameterConverter());
             converters.Add(new MsParameterCollectionConverter());
             converters.Add(new SysErrorConverter());
             converters.Add(new SysConnectionConverter());
+            converters.Add(new SysCommandConverter());
             converters.Add(new SysExceptionConverter());
             converters.Add(new SysParameterConverter());
             converters.Add(new SysParameterCollectionConverter());


### PR DESCRIPTION
In recording results:

 * Successful commands now have the SqlCommand instance as the Data and `sqlCommand` as the name
 * Failed command now have a `VerifyTests.SqlServer.LogErrorEntry` instance as the Data and `sqlError` as the name